### PR TITLE
feat: adding searchable expense list page

### DIFF
--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -1,0 +1,140 @@
+import * as React from 'react';
+import { Dialog as DialogPrimitive } from 'radix-ui';
+
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+import { XIcon } from 'lucide-react';
+
+function Dialog({ ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />;
+}
+
+function DialogTrigger({ ...props }: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
+}
+
+function DialogPortal({ ...props }: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
+}
+
+function DialogClose({ ...props }: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        'data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 fixed inset-0 isolate z-50 bg-black/80 duration-100 supports-backdrop-filter:backdrop-blur-xs',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean;
+}) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          'bg-background data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/5 fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-6 rounded-4xl p-6 text-sm ring-1 duration-100 sm:max-w-md',
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close data-slot="dialog-close" asChild>
+            <Button variant="ghost" className="absolute top-4 right-4" size="icon-sm">
+              <XIcon />
+              <span className="sr-only">Close</span>
+            </Button>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  );
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div data-slot="dialog-header" className={cn('flex flex-col gap-2', className)} {...props} />
+  );
+}
+
+function DialogFooter({
+  className,
+  showCloseButton = false,
+  children,
+  ...props
+}: React.ComponentProps<'div'> & {
+  showCloseButton?: boolean;
+}) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn('flex flex-col-reverse gap-2 sm:flex-row sm:justify-end', className)}
+      {...props}
+    >
+      {children}
+      {showCloseButton && (
+        <DialogPrimitive.Close asChild>
+          <Button variant="outline">Close</Button>
+        </DialogPrimitive.Close>
+      )}
+    </div>
+  );
+}
+
+function DialogTitle({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn('text-base leading-none font-medium', className)}
+      {...props}
+    />
+  );
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn(
+        'text-muted-foreground *:[a]:hover:text-foreground text-sm *:[a]:underline *:[a]:underline-offset-3',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+};

--- a/frontend/src/components/ui/table.tsx
+++ b/frontend/src/components/ui/table.tsx
@@ -1,0 +1,87 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+function Table({ className, ...props }: React.ComponentProps<'table'>) {
+  return (
+    <div data-slot="table-container" className="relative w-full overflow-x-auto">
+      <table
+        data-slot="table"
+        className={cn('w-full caption-bottom text-sm', className)}
+        {...props}
+      />
+    </div>
+  );
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<'thead'>) {
+  return <thead data-slot="table-header" className={cn('[&_tr]:border-b', className)} {...props} />;
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<'tbody'>) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn('[&_tr:last-child]:border-0', className)}
+      {...props}
+    />
+  );
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<'tfoot'>) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn('bg-muted/50 border-t font-medium [&>tr]:last:border-b-0', className)}
+      {...props}
+    />
+  );
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<'tr'>) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        'hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<'th'>) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        'text-foreground h-12 px-3 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<'td'>) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn('p-3 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0', className)}
+      {...props}
+    />
+  );
+}
+
+function TableCaption({ className, ...props }: React.ComponentProps<'caption'>) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn('text-muted-foreground mt-4 text-sm', className)}
+      {...props}
+    />
+  );
+}
+
+export { Table, TableHeader, TableBody, TableFooter, TableHead, TableRow, TableCell, TableCaption };

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -63,7 +63,7 @@ export const expenseApi = {
     amount: number;
     category: string;
     merchant: string;
-    expenseDate: string;
+    date: string;
     bank?: string;
   }) => api.post('/expenses', expense),
 
@@ -73,7 +73,7 @@ export const expenseApi = {
       amount: number;
       category: string;
       merchant: string;
-      expenseDate: string;
+      date: string;
       bank?: string;
     }
   ) => api.put(`/expenses/${id}`, expense),

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -5,7 +5,7 @@ export type Expense = {
   amount: number;
   category: string;
   merchant: string;
-  expenseDate: string;
+  date: string;
   bank?: string;
   createdAt: string;
   updatedAt: string;

--- a/frontend/src/pages/DashboardHome.tsx
+++ b/frontend/src/pages/DashboardHome.tsx
@@ -106,7 +106,7 @@ export default function DashboardHome() {
                 <div>
                   <p className="font-medium">{expense.merchant}</p>
                   <p className="text-muted-foreground text-sm">
-                    {expense.category} • {expense.expenseDate}
+                    {expense.category} • {expense.date}
                   </p>
                 </div>
                 <p className="font-semibold">${expense.amount.toFixed(2)}</p>

--- a/frontend/src/pages/ExpensesPage.tsx
+++ b/frontend/src/pages/ExpensesPage.tsx
@@ -1,13 +1,426 @@
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { expenseApi } from '@/lib/api';
+import { type Expense, type PageableResponse } from '@/lib/types';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Label } from '@/components/ui/label';
+import { ChevronLeft, ChevronRight, Pencil, Search, X } from 'lucide-react';
+import { Card } from '@/components/ui/card';
+
+type SearchFilters = {
+  merchant?: string;
+  category?: string;
+  bank?: string;
+  minAmount?: string;
+  maxAmount?: string;
+  startDate?: string;
+  endDate?: string;
+};
+
 export default function ExpensesPage() {
+  const queryClient = useQueryClient();
+  const [page, setPage] = useState(0);
+  const [pageSize, setPageSize] = useState(20);
+  const [searchFilters, setSearchFilters] = useState<SearchFilters>({});
+  const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
+  const [editingExpense, setEditingExpense] = useState<Expense | null>(null);
+  const [editForm, setEditForm] = useState({
+    amount: '',
+    category: '',
+    merchant: '',
+    date: '',
+    bank: '',
+  });
+
+  // Fetch expenses with pagination and filters
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['expenses', page, pageSize, searchFilters],
+    queryFn: async () => {
+      const params: Record<string, string | number> = {
+        page,
+        size: pageSize,
+        sort: 'date,desc',
+      };
+
+      // Add search filters
+      if (searchFilters.merchant) params.merchant = searchFilters.merchant;
+      if (searchFilters.category) params.category = searchFilters.category;
+      if (searchFilters.bank) params.bank = searchFilters.bank;
+      if (searchFilters.minAmount) params.minAmount = parseFloat(searchFilters.minAmount);
+      if (searchFilters.maxAmount) params.maxAmount = parseFloat(searchFilters.maxAmount);
+      if (searchFilters.startDate) params.startDate = searchFilters.startDate;
+      if (searchFilters.endDate) params.endDate = searchFilters.endDate;
+
+      const response = await expenseApi.getExpenses(params);
+      return response.data as PageableResponse<Expense>;
+    },
+  });
+
+  // Update expense mutation
+  const updateMutation = useMutation({
+    mutationFn: async (expense: { id: number; data: typeof editForm }) => {
+      return await expenseApi.updateExpense(expense.id, {
+        amount: parseFloat(expense.data.amount),
+        category: expense.data.category,
+        merchant: expense.data.merchant,
+        date: expense.data.date,
+        bank: expense.data.bank,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['expenses'] });
+      setIsEditDialogOpen(false);
+      setEditingExpense(null);
+    },
+  });
+
+  const handleEdit = (expense: Expense) => {
+    setEditingExpense(expense);
+    setEditForm({
+      amount: expense.amount.toString(),
+      category: expense.category,
+      merchant: expense.merchant,
+      date: expense.date,
+      bank: expense.bank || '',
+    });
+    setIsEditDialogOpen(true);
+  };
+
+  const handleSaveEdit = () => {
+    if (editingExpense) {
+      updateMutation.mutate({ id: editingExpense.id, data: editForm });
+    }
+  };
+
+  const handleSearchChange = (field: keyof SearchFilters, value: string) => {
+    setSearchFilters((prev) => ({
+      ...prev,
+      [field]: value || undefined,
+    }));
+    setPage(0); // Reset to first page on search
+  };
+
+  const clearFilters = () => {
+    setSearchFilters({});
+    setPage(0);
+  };
+
+  const hasActiveFilters = Object.values(searchFilters).some((v) => v !== undefined && v !== '');
+
   return (
     <div className="space-y-6">
       <div>
         <h2 className="text-3xl font-bold tracking-tight">Expenses</h2>
         <p className="text-muted-foreground">Manage and view all your expenses</p>
       </div>
-      <div className="rounded-lg border p-8 text-center">
-        <p className="text-muted-foreground">Expense list view coming soon...</p>
+
+      {/* Search Filters */}
+      <Card className="p-4">
+        <div className="space-y-4">
+          <div className="flex items-center justify-between">
+            <h3 className="flex items-center gap-2 text-lg font-semibold">
+              <Search className="h-5 w-5" />
+              Search & Filter
+            </h3>
+            {hasActiveFilters && (
+              <Button variant="outline" size="sm" onClick={clearFilters}>
+                <X className="mr-2 h-4 w-4" />
+                Clear Filters
+              </Button>
+            )}
+          </div>
+
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+            <div className="space-y-2">
+              <Label htmlFor="merchant-search">Merchant</Label>
+              <Input
+                id="merchant-search"
+                placeholder="Search by merchant..."
+                value={searchFilters.merchant || ''}
+                onChange={(e) => handleSearchChange('merchant', e.target.value)}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="category-search">Category</Label>
+              <Input
+                id="category-search"
+                placeholder="Search by category..."
+                value={searchFilters.category || ''}
+                onChange={(e) => handleSearchChange('category', e.target.value)}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="bank-search">Bank</Label>
+              <Input
+                id="bank-search"
+                placeholder="Search by bank..."
+                value={searchFilters.bank || ''}
+                onChange={(e) => handleSearchChange('bank', e.target.value)}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="min-amount">Min Amount</Label>
+              <Input
+                id="min-amount"
+                type="number"
+                step="0.01"
+                placeholder="0.00"
+                value={searchFilters.minAmount || ''}
+                onChange={(e) => handleSearchChange('minAmount', e.target.value)}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="max-amount">Max Amount</Label>
+              <Input
+                id="max-amount"
+                type="number"
+                step="0.01"
+                placeholder="0.00"
+                value={searchFilters.maxAmount || ''}
+                onChange={(e) => handleSearchChange('maxAmount', e.target.value)}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="start-date">Start Date</Label>
+              <Input
+                id="start-date"
+                type="date"
+                value={searchFilters.startDate || ''}
+                onChange={(e) => handleSearchChange('startDate', e.target.value)}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="end-date">End Date</Label>
+              <Input
+                id="end-date"
+                type="date"
+                value={searchFilters.endDate || ''}
+                onChange={(e) => handleSearchChange('endDate', e.target.value)}
+              />
+            </div>
+          </div>
+        </div>
+      </Card>
+
+      {/* Results and Pagination Controls */}
+      <div className="flex items-center justify-between">
+        <div className="text-muted-foreground text-sm">
+          {data && (
+            <>
+              Showing {data.numberOfElements} of {data.totalElements} expense
+              {data.totalElements !== 1 ? 's' : ''}
+            </>
+          )}
+        </div>
+
+        <div className="flex items-center gap-4">
+          <div className="flex items-center gap-2">
+            <Label htmlFor="page-size" className="text-sm">
+              Per page:
+            </Label>
+            <Select
+              value={pageSize.toString()}
+              onValueChange={(value) => {
+                setPageSize(parseInt(value));
+                setPage(0);
+              }}
+            >
+              <SelectTrigger id="page-size" className="w-20">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="10">10</SelectItem>
+                <SelectItem value="20">20</SelectItem>
+                <SelectItem value="50">50</SelectItem>
+                <SelectItem value="100">100</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setPage((p) => Math.max(0, p - 1))}
+              disabled={!data || data.first}
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </Button>
+            <span className="text-sm">
+              Page {data ? data.number + 1 : 1} of {data?.totalPages || 1}
+            </span>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setPage((p) => p + 1)}
+              disabled={!data || data.last}
+            >
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
       </div>
+
+      {/* Expenses Table */}
+      <Card>
+        <div className="overflow-x-auto">
+          {isLoading ? (
+            <div className="text-muted-foreground p-8 text-center">Loading expenses...</div>
+          ) : error ? (
+            <div className="text-destructive p-8 text-center">
+              Error loading expenses. Please try again.
+            </div>
+          ) : !data || data.content.length === 0 ? (
+            <div className="text-muted-foreground p-8 text-center">
+              {hasActiveFilters
+                ? 'No expenses found matching your search criteria.'
+                : 'No expenses found. Start by adding your first expense!'}
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Date</TableHead>
+                  <TableHead>Merchant</TableHead>
+                  <TableHead>Category</TableHead>
+                  <TableHead>Bank</TableHead>
+                  <TableHead className="text-right">Amount</TableHead>
+                  <TableHead className="w-[80px]">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {data.content.map((expense) => (
+                  <TableRow key={expense.id}>
+                    <TableCell className="font-medium">
+                      {new Date(expense.date).toLocaleDateString()}
+                    </TableCell>
+                    <TableCell>{expense.merchant}</TableCell>
+                    <TableCell>{expense.category}</TableCell>
+                    <TableCell>{expense.bank}</TableCell>
+                    <TableCell className="text-right font-medium">
+                      ${expense.amount.toFixed(2)}
+                    </TableCell>
+                    <TableCell>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => handleEdit(expense)}
+                        className="h-8 w-8 p-0"
+                      >
+                        <Pencil className="h-4 w-4" />
+                        <span className="sr-only">Edit expense</span>
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </div>
+      </Card>
+
+      {/* Edit Dialog */}
+      <Dialog open={isEditDialogOpen} onOpenChange={setIsEditDialogOpen}>
+        <DialogContent className="sm:max-w-[500px]">
+          <DialogHeader>
+            <DialogTitle>Edit Expense</DialogTitle>
+            <DialogDescription>
+              Make changes to your expense. Click save when you're done.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="grid gap-4 py-4">
+            <div className="space-y-2">
+              <Label htmlFor="edit-merchant">Merchant</Label>
+              <Input
+                id="edit-merchant"
+                value={editForm.merchant}
+                onChange={(e) => setEditForm({ ...editForm, merchant: e.target.value })}
+                placeholder="Enter merchant name"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="edit-category">Category</Label>
+              <Input
+                id="edit-category"
+                value={editForm.category}
+                onChange={(e) => setEditForm({ ...editForm, category: e.target.value })}
+                placeholder="Enter category"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="edit-bank">Bank</Label>
+              <Input
+                id="edit-bank"
+                value={editForm.bank}
+                onChange={(e) => setEditForm({ ...editForm, bank: e.target.value })}
+                placeholder="Enter bank name"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="edit-amount">Amount</Label>
+              <Input
+                id="edit-amount"
+                type="number"
+                step="0.01"
+                value={editForm.amount}
+                onChange={(e) => setEditForm({ ...editForm, amount: e.target.value })}
+                placeholder="0.00"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="edit-date">Date</Label>
+              <Input
+                id="edit-date"
+                type="date"
+                value={editForm.date}
+                onChange={(e) => setEditForm({ ...editForm, date: e.target.value })}
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setIsEditDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleSaveEdit} disabled={updateMutation.isPending}>
+              {updateMutation.isPending ? 'Saving...' : 'Save Changes'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }


### PR DESCRIPTION
This pull request introduces two new reusable UI component libraries for dialogs and tables, and updates the expense data model and its usage throughout the frontend to standardize the date field. The main themes are the addition of UI primitives and the renaming of the `expenseDate` field to `date` for consistency.

**UI Component Additions:**

* Added a new `Dialog` component library in `ui/dialog.tsx`, providing a set of dialog-related components (`Dialog`, `DialogContent`, `DialogHeader`, etc.) for consistent modal dialogs across the app.
* Added a new `Table` component library in `ui/table.tsx`, offering reusable table components (`Table`, `TableHeader`, `TableRow`, etc.) for standardized table layouts.

**Expense Model and API Updates:**

* Renamed the `expenseDate` field to `date` in the `Expense` type in `types.ts` to simplify and standardize field naming.
* Updated all relevant API calls in `api.ts` to use the new `date` field instead of `expenseDate` when creating or updating expenses. [[1]](diffhunk://#diff-fc0647beab64e4906eb6a581b0476dba8073601854e616d8ca3345539b0412b8L66-R66) [[2]](diffhunk://#diff-fc0647beab64e4906eb6a581b0476dba8073601854e616d8ca3345539b0412b8L76-R76)
* Updated the dashboard UI in `DashboardHome.tsx` to reference `expense.date` instead of `expense.expenseDate`.